### PR TITLE
:feat: support compile with lower glibc version

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5,6 +5,12 @@
  */ 
 #include "../code/log/log.h"
 #include "../code/pool/threadpool.h"
+#include <features.h>
+
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30
+#include <sys/syscall.h>
+#define gettid() syscall(SYS_gettid)
+#endif
 
 void TestLog() {
     int cnt = 0, level = 0;


### PR DESCRIPTION
当 glibc 版本低于 2.30 时会编译不通过, 原因是低版本 glibc 没有 gettid 函数, 直到 2.30 才支持.

参考 [glibc mail archive](https://sourceware.org/legacy-ml/libc-alpha/2019-08/msg00029.html)