### PR TITLE
Update threadpool & fix compile warning

### DIFF
--- a/code/http/httprequest.cpp
+++ b/code/http/httprequest.cpp
@@ -182,9 +182,7 @@ bool HttpRequest::UserVerify(const string &name, const string &pwd, bool isLogin
     assert(sql);
     
     bool flag = false;
-    unsigned int j = 0;
     char order[256] = { 0 };
-    MYSQL_FIELD *fields = nullptr;
     MYSQL_RES *res = nullptr;
     
     if(!isLogin) { flag = true; }
@@ -197,8 +195,6 @@ bool HttpRequest::UserVerify(const string &name, const string &pwd, bool isLogin
         return false; 
     }
     res = mysql_store_result(sql);
-    j = mysql_num_fields(res);
-    fields = mysql_fetch_fields(res);
 
     while(MYSQL_ROW row = mysql_fetch_row(res)) {
         LOG_DEBUG("MYSQL ROW: %s %s", row[0], row[1]);

--- a/code/log/log.h
+++ b/code/log/log.h
@@ -47,8 +47,6 @@ private:
     const char* path_;
     const char* suffix_;
 
-    int MAX_LINES_;
-
     int lineCount_;
     int toDay_;
 


### PR DESCRIPTION
## compile warning

g++
```
$ make
mkdir -p bin
cd build && make
make[1]: Entering directory '/home/ardxwe/github/WebServer/build'
g++ -std=c++14 -O2 -Wall -g  ../code/log/*.cpp ../code/pool/*.cpp ../code/timer/*.cpp ../code/http/*.cpp ../code/server/*.cpp ../code/buffer/*.cpp ../code/main.cpp -o ../bin/server  -pthread -lmysqlclient
../code/http/httprequest.cpp: In static member function ‘static bool HttpRequest::UserVerify(const string&, const string&, bool)’:
../code/http/httprequest.cpp:185:18: warning: variable ‘j’ set but not used [-Wunused-but-set-variable]
  185 |     unsigned int j = 0;
      |                  ^
../code/http/httprequest.cpp:187:18: warning: variable ‘fields’ set but not used [-Wunused-but-set-variable]
  187 |     MYSQL_FIELD *fields = nullptr;
      |                  ^~~~~~
make[1]: Leaving directory '/home/ardxwe/github/WebServer/build'
```
my g++ version

```
$ g++ -v
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/9/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:hsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 9.3.0-17ubuntu1~20.04' --with-bugurl=file:///usr/share/doc/gcc-9/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++,gm2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-9 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-9-HskZEa/gcc-9-9.3.0/debian/tmp-nvptx/usr,hsa --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)
```

clang++
```
$ make
mkdir -p bin
cd build && make
make[1]: Entering directory '/home/ardxwe/github/WebServer/build'
clang++ -std=c++14 -O2 -Wall -g  ../code/log/*.cpp ../code/pool/*.cpp ../code/timer/*.cpp ../code/http/*.cpp ../code/server/*.cpp ../code/buffer/*.cpp ../code/main.cpp -o ../bin/server  -pthread -lmysqlclient
In file included from ../code/log/log.cpp:6:
../code/log/log.h:50:9: warning: private field 'MAX_LINES_' is not used [-Wunused-private-field]
    int MAX_LINES_;
        ^
1 warning generated.
make[1]: Leaving directory '/home/ardxwe/github/WebServer/build'
```

my clang++ version

```
$ clang++ -v
clang version 10.0.0-4ubuntu1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/9
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/9
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/9
Candidate multilib: .;@m64
Selected multilib: .;@m64
```

## threadpool

- Use `join` instead of `detach`

In properly maintained C++ code std::thread::detach should not be used at all. Programmer must ensure that all the created threads gracefully exit releasing all the acquired resources and performing other necessary cleanup actions. This implies that giving up ownership of threads by invoking detach is not an option and therefore join should be used in all scenarios.[stackoverflow](https://stackoverflow.com/questions/22803600/when-should-i-use-stdthreaddetach)


- Update cv wait `API`

When the condition variable is notified, a timeout expires, or a spurious wakeup occurs, the thread is awakened, and the mutex is atomically reacquired. The thread should then check the condition and resume waiting if the wake up was spurious.[cppreference](https://zh.cppreference.com/w/cpp/thread/condition_variable)