### PR TITLE
Update webserver.cpp

### DIFF
--- a/code/server/webserver.cpp
+++ b/code/server/webserver.cpp
@@ -22,12 +22,14 @@ WebServer::WebServer(
     HttpConn::userCount = 0;
     HttpConn::srcDir = srcDir_;
     SqlConnPool::Instance()->Init("localhost", sqlPort, sqlUser, sqlPwd, dbName, connPoolNum);
+    if(openLog) {
+                Log::Instance()->init(logLevel, "./log", ".log", logQueSize);
+    }
 
     InitEventMode_(trigMode);
     if(!InitSocket_()) { isClose_ = true;}
 
     if(openLog) {
-        Log::Instance()->init(logLevel, "./log", ".log", logQueSize);
         if(isClose_) { LOG_ERROR("========== Server init error!=========="); }
         else {
             LOG_INFO("========== Server init ==========");


### PR DESCRIPTION
log日志库的初始化在socket初始化之后会造成日志无法记录socket初始化过程中的相关错误，因此commit中将日志初始化前移至socket初始化之前。#88